### PR TITLE
Redirect feature

### DIFF
--- a/src/fauxmoESP.cpp
+++ b/src/fauxmoESP.cpp
@@ -313,7 +313,17 @@ bool fauxmoESP::_onTCPRequest(AsyncClient *client, bool isGet, String url, Strin
        		return _onTCPControl(client, url, body);
 		}
 	}
-
+         
+	if (_redirect_port!=0){
+    		char response[strlen_P(FAUXMO_REDIRECT)+5];
+        	snprintf_P(
+            	response, sizeof(response),
+            	FAUXMO_REDIRECT,
+            	_redirect_port
+        	);
+    	_sendTCPResponse(client, "200 OK", response, "text/html");
+	}
+	
 	return false;
 
 }

--- a/src/fauxmoESP.h
+++ b/src/fauxmoESP.h
@@ -102,6 +102,7 @@ class fauxmoESP {
         void enable(bool enable);
         void createServer(bool internal) { _internal = internal; }
         void setPort(unsigned long tcp_port) { _tcp_port = tcp_port; }
+	void setRedirect(unsigned long redirect_port) { _redirect_port = redirect_port; }
         void handle();
 
     private:
@@ -110,6 +111,7 @@ class fauxmoESP {
         bool _enabled = false;
         bool _internal = true;
         unsigned int _tcp_port = FAUXMO_TCP_PORT;
+	unsigned int _redirect_port = 0;
         std::vector<fauxmoesp_device_t> _devices;
 		#ifdef ESP8266
         WiFiEventHandler _handler;

--- a/src/templates.h
+++ b/src/templates.h
@@ -39,6 +39,10 @@ PROGMEM const char FAUXMO_TCP_STATE_RESPONSE[] = "["
     "{\"success\":{\"/lights/%d/state/bri\":%d}}"   // not needed?
 "]";
 
+PROGMEM const char FAUXMO_REDIRECT[] = "<!DOCTYPE HTML><html><body>"
+"<script>window.location = '<http://'+window.location.hostname+':%d'+window.location.pathname+window.location.search;</script>">
+"</body></html>";
+
 // Working with gen1 and gen3, ON/OFF/%, gen3 requires TCP port 80
 PROGMEM const char FAUXMO_DEVICE_JSON_TEMPLATE[] = "{"
     "\"type\": \"Extended color light\","

--- a/src/templates.h
+++ b/src/templates.h
@@ -40,7 +40,7 @@ PROGMEM const char FAUXMO_TCP_STATE_RESPONSE[] = "["
 "]";
 
 PROGMEM const char FAUXMO_REDIRECT[] = "<!DOCTYPE HTML><html><body>"
-"<script>window.location = '<http://'+window.location.hostname+':%d'+window.location.pathname+window.location.search;</script>">
+"<script>window.location = '<http://'+window.location.hostname+':%d'+window.location.pathname+window.location.search;</script>"
 "</body></html>";
 
 // Working with gen1 and gen3, ON/OFF/%, gen3 requires TCP port 80


### PR DESCRIPTION
With gen3 devices is mandatory to use port 80...
so i have to use a different port for my webserver for example port 8080.
with this mod if add after the line:
fauxmo.setPort(80); // This is required for gen3 devices

this one
fauxmo.setRedirect(8080); //redirect everything not found to port 8080
all calls to fauxmoesp that is not processed will be redirected to port 8080