### PR TITLE
Add RGB color support

### DIFF
--- a/src/fauxmoESP.cpp
+++ b/src/fauxmoESP.cpp
@@ -341,7 +341,7 @@ bool fauxmoESP::_onTCPControl(AsyncClient *client, String url, String body) {
 			snprintf_P(
 				response, sizeof(response),
 				FAUXMO_TCP_STATE_RESPONSE,
-				id+1, _devices[id].state ? "true" : "false", id+1, _devices[id].value
+				id+1, _devices[id].state ? "true" : "false"
 			);
 			_sendTCPResponse(client, "200 OK", response, "text/xml");
 

--- a/src/fauxmoESP.cpp
+++ b/src/fauxmoESP.cpp
@@ -525,6 +525,7 @@ unsigned char fauxmoESP::addDevice(const char * device_name) {
 
     snprintf(device.uniqueid, FAUXMO_DEVICE_UNIQUE_ID_LENGTH, "%s:%s-%02X", mac.c_str(), "00:00", device_id);
 
+
     // Attach
     _devices.push_back(device);
 

--- a/src/fauxmoESP.h
+++ b/src/fauxmoESP.h
@@ -81,7 +81,7 @@ typedef struct {
     char * name;
     bool state;
     unsigned char value;
-    byte rgb[4];
+    byte rgb[3] = {255, 255, 255};
     char uniqueid[FAUXMO_DEVICE_UNIQUE_ID_LENGTH];
 } fauxmoesp_device_t;
 

--- a/src/fauxmoESP.h
+++ b/src/fauxmoESP.h
@@ -75,11 +75,13 @@ THE SOFTWARE.
 #include "templates.h"
 
 typedef std::function<void(unsigned char, const char *, bool, unsigned char)> TSetStateCallback;
+typedef std::function<void(unsigned char, const char *, bool, unsigned char, byte *)> TSetStateWithColorCallback;
 
 typedef struct {
     char * name;
     bool state;
     unsigned char value;
+    byte rgb[4];
     char uniqueid[FAUXMO_DEVICE_UNIQUE_ID_LENGTH];
 } fauxmoesp_device_t;
 
@@ -97,9 +99,12 @@ class fauxmoESP {
         char * getDeviceName(unsigned char id, char * buffer, size_t len);
         int getDeviceId(const char * device_name);
         void setDeviceUniqueId(unsigned char id, const char *uniqueid);
-        void onSetState(TSetStateCallback fn) { _setCallback = fn; }
+        void onSetState(TSetStateCallback fn) { _setStateCallback = fn; }
+        void onSetState(TSetStateWithColorCallback fn) { _setStateWithColorCallback = fn; }
         bool setState(unsigned char id, bool state, unsigned char value);
         bool setState(const char * device_name, bool state, unsigned char value);
+        bool setState(unsigned char id, bool state, unsigned char value, byte* rgb);
+        bool setState(const char * device_name, bool state, unsigned char value, byte* rgb);
         bool process(AsyncClient *client, bool isGet, String url, String body);
         void enable(bool enable);
         void createServer(bool internal) { _internal = internal; }
@@ -118,7 +123,8 @@ class fauxmoESP {
 		#endif
         WiFiUDP _udp;
         AsyncClient * _tcpClients[FAUXMO_TCP_MAX_CLIENTS];
-        TSetStateCallback _setCallback = NULL;
+        TSetStateCallback _setStateCallback = NULL;
+        TSetStateWithColorCallback _setStateWithColorCallback = NULL;
 
         String _deviceJson(unsigned char id, bool all); 	// all = true means we are listing all devices so use full description template
 
@@ -136,4 +142,6 @@ class fauxmoESP {
 
         String _byte2hex(uint8_t zahl);
         String _makeMD5(String text);
+        byte* _hs2rgb(uint16_t hue, uint8_t sat);
+        byte* _ct2rgb(uint16_t ct);
 };

--- a/src/templates.h
+++ b/src/templates.h
@@ -35,8 +35,7 @@ PROGMEM const char FAUXMO_TCP_HEADERS[] =
     "Connection: close\r\n\r\n";
 
 PROGMEM const char FAUXMO_TCP_STATE_RESPONSE[] = "["
-    "{\"success\":{\"/lights/%d/state/on\":%s}},"
-    "{\"success\":{\"/lights/%d/state/bri\":%d}}"   // not needed?
+    "{\"success\":{\"/lights/%d/state/on\":%s}}"
 "]";
 
 // Working with gen1 and gen3, ON/OFF/%, gen3 requires TCP port 80


### PR DESCRIPTION
This change enables the the library to handle RGB color values. It seamlessly integrates with existing handlers, maintaining backward compatibility for those that don't utilize RGB functionality. It supports hue/saturation and color temperature (shades of white) formats used by Alexa.