### PR TITLE
Update dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -19,19 +19,22 @@
     },
     "dependencies": [ 
         {
-            "name": "ESPAsyncTCP",
-            "version": ">=1.2.0",
-            "platforms": "espressif8266"
+          "owner": "ESP32Async",
+          "name": "AsyncTCP",
+          "version": "^3.3.5",
+          "platforms": "espressif32"
         },
         {
-            "name": "AsyncTCP",
-            "version": ">=1.0.1",
-            "platforms": "espressif32"
+          "owner": "ESP32Async",
+          "name": "ESPAsyncTCP",
+          "version": "^2.0.0",
+          "platforms": "espressif8266"
         },
         {
-            "name": "AsyncTCP_RP2040W",
-            "version": ">=1.1.0",
-            "platforms": "rp2040"
+          "owner": "khoih-prog",
+          "name": "AsyncTCP_RP2040W",
+          "version": "^1.2.0",
+          "platforms": "raspberrypi"
         }
     ],
     "headers": "fauxmoESP.h"


### PR DESCRIPTION
The ESP AsyncTCP did now officially move to a ESP32Async. This way the new Pio registry entry is used.
Otherwise this always would point to me-no-dev AsyncTCP at 3.3.2
Addidtionally the new ESPAsyncWebServer uses the same dependencies.