### PR TITLE
Fix client close method in fauxmoESP.cpp

### DIFF
--- a/src/fauxmoESP.cpp
+++ b/src/fauxmoESP.cpp
@@ -485,7 +485,7 @@ void fauxmoESP::_onTCPClient(AsyncClient *client) {
         c->free();
         delete c;
     });
-    client->close(true);
+    client->close();
 
 }
 


### PR DESCRIPTION
'void AsyncClient::close(bool)' is deprecated